### PR TITLE
[Implements #38] Store De-id Configuration State in URL

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -10822,11 +10822,6 @@
         "sha.js": "^2.4.8"
       }
     },
-    "percentage-encode-char": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/percentage-encode-char/-/percentage-encode-char-0.1.0.tgz",
-      "integrity": "sha1-8VAJYa9jwjsu7vkD/km/TUnuZdk="
-    },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -10822,6 +10822,11 @@
         "sha.js": "^2.4.8"
       }
     },
+    "percentage-encode-char": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/percentage-encode-char/-/percentage-encode-char-0.1.0.tgz",
+      "integrity": "sha1-8VAJYa9jwjsu7vkD/km/TUnuZdk="
+    },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -7045,6 +7045,19 @@
       "resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
       "integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ=="
     },
+    "history": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
+      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "loose-envify": "^1.2.0",
+        "resolve-pathname": "^3.0.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0",
+        "value-equal": "^1.0.1"
+      }
+    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -7053,6 +7066,14 @@
         "hash.js": "^1.0.3",
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "requires": {
+        "react-is": "^16.7.0"
       }
     },
     "hoopy": {
@@ -9911,6 +9932,15 @@
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
       "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="
     },
+    "mini-create-react-context": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.4.1.tgz",
+      "integrity": "sha512-YWCYEmd5CQeHGSAKrYvXgmzzkrvssZcuuQDDeqkT+PziKGMgE+0MCCtcKbROzocGBG1meBLl2FotlRwf4gAzbQ==",
+      "requires": {
+        "@babel/runtime": "^7.12.1",
+        "tiny-warning": "^1.0.3"
+      }
+    },
     "mini-css-extract-plugin": {
       "version": "0.11.3",
       "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.11.3.tgz",
@@ -12344,6 +12374,52 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.8.3.tgz",
       "integrity": "sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg=="
     },
+    "react-router": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.2.0.tgz",
+      "integrity": "sha512-smz1DUuFHRKdcJC0jobGo8cVbhO3x50tCL4icacOlcwDOEQPq4TMqwx3sY1TP+DvtTgz4nm3thuo7A+BK2U0Dw==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "history": "^4.9.0",
+        "hoist-non-react-statics": "^3.1.0",
+        "loose-envify": "^1.3.1",
+        "mini-create-react-context": "^0.4.0",
+        "path-to-regexp": "^1.7.0",
+        "prop-types": "^15.6.2",
+        "react-is": "^16.6.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "path-to-regexp": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        }
+      }
+    },
+    "react-router-dom": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.2.0.tgz",
+      "integrity": "sha512-gxAmfylo2QUjcwxI63RhQ5G85Qqt4voZpUXSEqCwykV0baaOTQDR1f0PmY8AELqIyVc0NEZUj0Gov5lNGcXgsA==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "history": "^4.9.0",
+        "loose-envify": "^1.3.1",
+        "prop-types": "^15.6.2",
+        "react-router": "5.2.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
+      }
+    },
     "react-scripts": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-4.0.1.tgz",
@@ -12819,6 +12895,11 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
+    },
+    "resolve-pathname": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
+      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng=="
     },
     "resolve-url": {
       "version": "0.2.1",
@@ -14467,6 +14548,16 @@
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q="
     },
+    "tiny-invariant": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.1.0.tgz",
+      "integrity": "sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw=="
+    },
+    "tiny-warning": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
+      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
+    },
     "tmpl": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
@@ -14941,6 +15032,11 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "value-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
+      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
     },
     "vary": {
       "version": "1.1.2",

--- a/client/package.json
+++ b/client/package.json
@@ -8,6 +8,7 @@
     "@testing-library/user-event": "^12.6.0",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
+    "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.1",
     "typescript": "^4.1.3",
     "web-vitals": "^0.2.4"

--- a/client/package.json
+++ b/client/package.json
@@ -6,7 +6,6 @@
     "@testing-library/jest-dom": "^5.11.6",
     "@testing-library/react": "^11.2.2",
     "@testing-library/user-event": "^12.6.0",
-    "percentage-encode-char": "^0.1.0",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-router-dom": "^5.2.0",

--- a/client/package.json
+++ b/client/package.json
@@ -6,6 +6,7 @@
     "@testing-library/jest-dom": "^5.11.6",
     "@testing-library/react": "^11.2.2",
     "@testing-library/user-event": "^12.6.0",
+    "percentage-encode-char": "^0.1.0",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-router-dom": "^5.2.0",

--- a/client/src/components/App.js
+++ b/client/src/components/App.js
@@ -5,6 +5,7 @@ import React from 'react';
 import { Configuration } from '../runtime';
 import { DeidentifiedText, deidentificationStates } from './DeidentifiedText';
 import { DeidentificationConfigForm } from './DeidentificationConfigForm';
+import { encodeString, decodeString } from '../stringSmuggler';
 
 const deidentifiedNotesApi = new DeidentifiedNotesApi(new Configuration({basePath: "http://localhost:8080/api/v1"})) // FIXME: Figure out how to handle hostname
 
@@ -17,7 +18,7 @@ class App extends React.Component {
     const queryInUrl = location.pathname.slice(1);
     let deidentifyRequest;
     if (queryInUrl) {
-      deidentifyRequest = JSON.parse(queryInUrl)
+      deidentifyRequest = JSON.parse(decodeString(queryInUrl));
     } else {
       deidentifyRequest = {
         deidentificationConfigurations: [{
@@ -41,7 +42,7 @@ class App extends React.Component {
   }
 
   updateUrl = () => {
-    const queryInUrl = "/" + JSON.stringify(this.state.deidentifyRequest);
+    const queryInUrl = "/" + encodeString(JSON.stringify(this.state.deidentifyRequest));
     this.props.history.push(queryInUrl);
   }
 

--- a/client/src/components/App.js
+++ b/client/src/components/App.js
@@ -11,17 +11,30 @@ const deidentifiedNotesApi = new DeidentifiedNotesApi(new Configuration({basePat
 class App extends React.Component {
   constructor(props) {
     super(props);
+    const { location } = props;
+    const queryInUrl = location.pathname.slice(1);
+    let deidentificationConfigs;
+    if (queryInUrl) {
+      deidentificationConfigs = JSON.parse(queryInUrl)
+    } else {
+      deidentificationConfigs = [{
+          confidenceThreshold: 20,
+          deidentificationStrategy: {maskingCharConfig: {maskingChar: "*"}},
+          annotationTypes: ["text_person_name", "text_physical_address", "text_date"]
+      }];
+    }
     this.state = {
       originalNoteText: "",
       deidentifiedNoteText: deidentificationStates.EMPTY,
-      deidentificationConfigs: [{
-        confidenceThreshold: 20,
-        deidentificationStrategy: {maskingCharConfig: {maskingChar: "*"}},
-        annotationTypes: ["text_person_name", "text_physical_address", "text_date"]
-      }]
+      deidentificationConfigs: deidentificationConfigs
     };
 
     this.handleTextAreaChange = this.handleTextAreaChange.bind(this);
+  }
+
+  updateUrl = () => {
+    const queryInUrl = "/" + JSON.stringify(this.state.deidentificationConfigs);
+    this.props.history.push(queryInUrl);
   }
 
   deidentifyNote = () => {
@@ -60,9 +73,10 @@ class App extends React.Component {
       ...oldDeidentificationConfig,
       ...newSettings
     };
-    this.setState({
-      deidentificationConfigs: deidentificationConfigs
-    });
+    this.setState(
+      { deidentificationConfigs: deidentificationConfigs },
+      () => this.updateUrl()
+    );
   }
 
   handleTextAreaChange(event) {
@@ -79,17 +93,19 @@ class App extends React.Component {
       annotationTypes: ["text_person_name", "text_physical_address", "text_date"]
     };
     deidentificationConfigs.push(newDeidConfig);
-    this.setState({
-      deidentificationConfigs: deidentificationConfigs
-    });
+    this.setState(
+      { deidentificationConfigs: deidentificationConfigs },
+      () => this.updateUrl()
+    );
   }
 
   deleteDeidConfig = (index) => {
     let deidentificationConfigs = [...this.state.deidentificationConfigs];
     deidentificationConfigs.splice(index, 1);
-    this.setState({
-      deidentificationConfigs: deidentificationConfigs
-    });
+    this.setState(
+      { deidentificationConfigs: deidentificationConfigs },
+      () => this.updateUrl()
+    );
   }
 
   render() {

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -1,12 +1,17 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import { BrowserRouter, Route, Switch } from 'react-router-dom';
 import './index.css';
 import App from './components/App';
 import reportWebVitals from './reportWebVitals';
 
 ReactDOM.render(
   <React.StrictMode>
-    <App />
+    <BrowserRouter>
+      <Switch>
+        <Route path="/" component={App} />
+      </Switch>
+    </BrowserRouter>
   </React.StrictMode>,
   document.getElementById('root')
 );

--- a/client/src/stringSmuggler.js
+++ b/client/src/stringSmuggler.js
@@ -1,17 +1,24 @@
 // React router behaves very weirdly with any URL containing a "%" (it
 // automatically decodes them and there's nothing we can do about it). The
-// work-around here is to percent-encode every single character, then remove the
-// percent sign from each two-char chunk (e.g. "Hello" -> "%68%65%6c%6c%6f" ->
-// "68656c6c6f"), then use that as the url.
+// work-around here is to char-encode every single character in base 36 (0-9,
+// a-z), then join each code with a hyphen (e.g. "Hello" -> "2w-2t-30-30-33"),
+// then use that as the url.
 
-function encodeChar(c) {
-  return c.charCodeAt(0).toString(16);
+const base = 36;
+const divider = '-';
+
+function encodeChar(char) {
+  return char.charCodeAt(0).toString(base);
+}
+
+function decodeChar(code) {
+  return String.fromCharCode(parseInt(code, base))
 }
 
 export function encodeString(decodedString) {
-  return [...decodedString].map((char) => encodeChar(char)).join('');
+  return [...decodedString].map((char) => encodeChar(char)).join(divider);
 }
 
 export function decodeString(encodedString) {
-  return encodedString.match(/.{1,2}/g).map((chunk) => decodeURIComponent("%"+chunk)).join('');
+  return encodedString.split('-').map((code) => decodeChar(code)).join('');
 }

--- a/client/src/stringSmuggler.js
+++ b/client/src/stringSmuggler.js
@@ -1,0 +1,17 @@
+// React router behaves very weirdly with any URL containing a "%" (it
+// automatically decodes them and there's nothing we can do about it). The
+// work-around here is to percent-encode every single character, then remove the
+// percent sign from each two-char chunk (e.g. "Hello" -> "%68%65%6c%6c%6f" ->
+// "68656c6c6f"), then use that as the url.
+
+function encodeChar(c) {
+  return c.charCodeAt(0).toString(16);
+}
+
+export function encodeString(decodedString) {
+  return [...decodedString].map((char) => encodeChar(char)).join('');
+}
+
+export function decodeString(encodedString) {
+  return encodedString.match(/.{1,2}/g).map((chunk) => decodeURIComponent("%"+chunk)).join('');
+}


### PR DESCRIPTION
This PR makes the client store the de-id configuration state in the URL. Every time the user changes, adds, or deletes a de-id config step, the URL gets changed. You can copy and paste the same URL to a different browser window/tab or refresh the page and it will have the same de-id configuration.