### PR TITLE
Store State in URL More Efficiently

### DIFF
--- a/client/src/stringSmuggler.js
+++ b/client/src/stringSmuggler.js
@@ -4,21 +4,12 @@
 // a-z), then join each code with a hyphen (e.g. "Hello" -> "2w-2t-30-30-33"),
 // then use that as the url.
 
-const base = 36;
-const divider = '-';
-
-function encodeChar(char) {
-  return char.charCodeAt(0).toString(base);
-}
-
-function decodeChar(code) {
-  return String.fromCharCode(parseInt(code, base))
-}
-
 export function encodeString(decodedString) {
-  return [...decodedString].map((char) => encodeChar(char)).join(divider);
+  let buff = new Buffer(decodedString);
+  return buff.toString('base64');
 }
 
 export function decodeString(encodedString) {
-  return encodedString.split('-').map((code) => decodeChar(code)).join('');
+  let buff = new Buffer(encodedString, 'base64');
+  return buff.toString('utf-8');
 }


### PR DESCRIPTION
The way I was previously storing page state in the URL was silly and unnecessarily complicated. Whoops! This simplifies it a lot and makes the URL look more like (example, new way):

"http://localhost/eyJkZWlkZW50aWZpY2F0aW9uQ29uZmlndXJhdGlvbnMiOlt7ImNvbmZpZGVuY2VUaHJlc2hvbGQiOjIwLCJkZWlkZW50aWZpY2F0aW9uU3RyYXRlZ3kiOnsibWFza2luZ0NoYXJDb25maWciOnsibWFza2luZ0NoYXIiOiIqIn19LCJhbm5vdGF0aW9uVHlwZXMiOlsidGV4dF9wZXJzb25fbmFtZSIsInRleHRfcGh5c2ljYWxfYWRkcmVzcyIsInRleHRfZGF0ZSJdfV0sIm5vdGUiOnsidGV4dCI6ImFzbGRma2pcblxuZmV3amxqZVxuYWxza2ZqbGV3amZ3ZVxuXG5cbmFsa3NkamZsZXdqXG5cbmFcblxuXG5hc2Rmc2Zld1xuXG5cbmFzZmRld2VmXG5zZGZrbGFzamZlayIsIm5vdGVUeXBlIjoiQVNERiJ9fQ=="

instead of (example, old way):

"http://localhost:3000/3f-y-2s-2t-2x-2s-2t-32-38-2x-2u-2x-2r-2p-38-2x-33-32-1v-33-32-2u-2x-2v-39-36-2p-38-2x-33-32-37-y-1m-2j-3f-y-2r-33-32-2u-2x-2s-2t-32-2r-2t-2c-2w-36-2t-37-2w-33-30-2s-y-1m-1e-1c-18-y-2s-2t-2x-2s-2t-32-38-2x-2u-2x-2r-2p-38-2x-33-32-2b-38-36-2p-38-2t-2v-3d-y-1m-3f-y-31-2p-37-2z-2x-32-2v-1v-2w-2p-36-1v-33-32-2u-2x-2v-y-1m-3f-y-31-2p-37-2z-2x-32-2v-1v-2w-2p-36-y-1m-y-16-y-3h-3h-18-y-2p-32-32-33-38-2p-38-2x-33-32-2c-3d-34-2t-37-y-1m-2j-y-38-2t-3c-38-2n-34-2t-36-37-33-32-2n-32-2p-31-2t-y-18-y-38-2t-3c-38-2n-34-2w-3d-37-2x-2r-2p-30-2n-2p-2s-2s-36-2t-37-37-y-18-y-38-2t-3c-38-2n-2s-2p-38-2t-y-2l-3h-2l-18-y-32-33-38-2t-y-1m-3f-y-38-2t-3c-38-y-1m-y-1t-2b-1w-y-18-y-32-33-38-2t-2c-3d-34-2t-y-1m-y-1t-2b-1w-1y-y-3h-3h"