### PR TITLE
Fix Bug that Broke Requests to Annotators

### DIFF
--- a/server/openapi_server/controllers/deidentified_notes_controller.py
+++ b/server/openapi_server/controllers/deidentified_notes_controller.py
@@ -26,7 +26,7 @@ def create_deidentified_notes():  # noqa: E501
             annotations[annotation_type] = annotators.annotate(note, annotation_type)
 
         # De-identify note
-        deidentified_note = Note.from_dict(note.to_dict())
+        deidentified_note = Note.from_dict({note.attribute_map[key]: value for key, value in note.to_dict().items()})
         deidentified_annotations = {key: value.copy() for key, value in annotations.items()}
 
         deid_config: DeidentificationConfig

--- a/server/openapi_server/utils/annotators.py
+++ b/server/openapi_server/utils/annotators.py
@@ -24,7 +24,7 @@ def annotate(note: Note, annotation_type: str):
     url = '%s/%s' % (BASE_URLS[annotation_type], ANNOTATION_TYPES_CAMEL_CASE[annotation_type])
     response = requests.post(
         url=url,
-        json=note.to_dict(),
+        json={'note': {note.attribute_map[key]: value for key, value in note.to_dict().items() if value is not None}},
         headers={'Content-Type': 'application/json', 'charset': 'utf-8'}
     )
     return response.json()[ANNOTATION_TYPES_CAMEL_CASE[annotation_type]]
@@ -41,3 +41,4 @@ def get_annotators_info():
         tools.append(Tool.from_dict(response.json()))
     tool_dependencies = ToolDependencies(tool_dependencies=tools)
     return tool_dependencies
+


### PR DESCRIPTION
Note.to_dict() produces attribute names in snake case (e.g.
{'note_type': 'xyz', 'text': 'blablabla'}), wherease Note.from_dict()
expects attribute names in lower camel case (e.g. {'noteType': 'xyz',
'text': 'blabalba'}). I have absolutely no idea why it does this, but
I managed to make it work.

I think the spec for an annotation request changed slightly as well (it
used to just be the note itself, now it is a JSON object {'note':
{'text': 'blabla', 'noteType': 'xyz'}}). This fixes that as well.

This would have been producing a 500 error (it was for me). After
fixing this, and running with a fresh download, I'm not getting any
CORS errors, though. Just going to `http://localhost/` works great on
my machine. Let me know if there are still any problems on yours
@tschaffter .