### PR TITLE
Path version 1.0.0 before release

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ This repository provides a Python-Flask implementation of the [NLP Sandbox PHI
 Deidentifier]. A PHI Deidentifier takes as input a clinical note and a
 configuration object, and outputs the de-identified clinical note.
 
+All the NLP Sandbox Tools are shipped with a web interface (see Section
+[Accessing the UI](#Accessing-the-UI)). The PHI Deidentifier also has a [React
+interface] that enables the de-identification of clinical notes in a more
+user-friendly way.
+
 ### Specification
 
 - PHI Deidentifier API version: 1.0.0
@@ -295,3 +300,4 @@ Thinking about contributing to this project? Get started by reading our
 [NLP Sandbox Date Annotator]: https://nlpsandbox.github.io/nlpsandbox-schemas/date-annotator/1.0.0/docs/
 [NLP Sandbox Person Name Annotator]: https://nlpsandbox.github.io/nlpsandbox-schemas/person-name-annotator/1.0.0/docs/
 [NLP Sandbox Physical Address Annotator]: https://nlpsandbox.github.io/nlpsandbox-schemas/physical-address-annotator/1.0.0/docs/
+[React interface]: https://github.com/nlpsandbox/phi-deidentifier-app

--- a/server/openapi_server/controllers/tool_controller.py
+++ b/server/openapi_server/controllers/tool_controller.py
@@ -12,14 +12,15 @@ def get_tool():  # noqa: E501
     """
     tool = Tool(
         name="phi-deidentifier",
-        version="0.3.1",
+        version="1.0.0",
         license=License.APACHE_2_0,
         repository="github:nlpsandbox/phi-deidentifier",
         description="NLP Sandbox PHI Deidentifier",
         author="The NLP Sandbox Team",
         author_email="thomas.schaffter@sagebionetworks.org",
         url="https://github.com/nlpsandbox/phi-deidentifier",
-        tool_type="nlpsandbox:phi-deidentifier"
+        tool_type="nlpsandbox:phi-deidentifier",
+        tool_api_version="1.0.0"
     )
     return tool, 200
 


### PR DESCRIPTION
- [x] Fix output of `/api/v1/tool`
- [x] Physical address annotator returned `toolVersion` < 1.0.0 for its 1.0.0 release?
- [x] Add link to React app to the top of the README