### PR TITLE
Increase Buffer Size

### DIFF
--- a/server/uwsgi.ini
+++ b/server/uwsgi.ini
@@ -3,6 +3,7 @@
 # The variables http and *-socket are passed as command line arguments and
 # must not be specified in this file.
 wsgi-file = openapi_server/__main__.py
+buffer-size=32768
 callable = app
 uid = www-data
 gid = www-data


### PR DESCRIPTION
The NginX reverse proxy sometimes increases the request block sizes to more than the default maximum for this server. This fixes issue nlpsandbox/phi-deidentifier-app#46.